### PR TITLE
Add custom remove formatting handler so that it doesn't break table

### DIFF
--- a/demo/script.ts
+++ b/demo/script.ts
@@ -8,7 +8,13 @@ window.onload = () => {
   const quill = new Quill("#editor-wrapper", {
     theme: "snow",
     modules: {
-      toolbar: [[{ header: [1, 2, false] }], ["bold", "italic", "underline"], ["image", "code-block"]],
+      toolbar: [
+        [{ header: [1, 2, false] }],
+        ["bold", "italic", "underline"],
+        ["image", "code-block"],
+        [{ list: "ordered" }, { list: "bullet" }],
+        ["clean"],
+      ],
       imageResize: true,
       table: false,
       "better-table": {

--- a/src/modules/better-table/quill-better-table.ts
+++ b/src/modules/better-table/quill-better-table.ts
@@ -46,6 +46,10 @@ export default class BetterTable extends Module {
   constructor(quill, options) {
     super(quill, options);
 
+    const toolbar = this.quill.getModule("toolbar");
+    // use custom remove text formatting that doesn't break the table
+    toolbar.addHandler("clean", () => this.removeTextFormatting());
+
     // handle click on quill-better-table
     this.quill.root.addEventListener(
       "click",
@@ -159,6 +163,21 @@ export default class BetterTable extends Module {
     quill.clipboard.matchers = quill.clipboard.matchers.filter((matcher) => {
       return matcher[0] !== "tr";
     });
+  }
+
+  // doesn't affect line formatting - lists, bullets, which breaks tables in original function
+  removeTextFormatting(range = this.quill.getSelection()) {
+    if (range) {
+      this.quill.formatText(range, {
+        bold: false,
+        italic: false,
+        underline: false,
+        strike: false,
+        color: false,
+        background: false,
+        script: false,
+      });
+    }
   }
 
   getTable(range = this.quill.getSelection()) {


### PR DESCRIPTION
### Goal
Fix bug that is caused by clicking `remove formatting` when selected text is in a table. 

### Background

The table breaks completely by this bug, see https://github.com/mild-blue/slp/issues/3417

### Implementation

When `BetterTable` module is used, there's a custom handler added for formatting so that the table remains the same. The new implemented function just does formatiing for text not for lines. 

This cause that line formatting like bullets and ordered won't be changed by this handler and user has to do it manually. But creating of an ordered list in tables is broken anyway, see https://github.com/mild-blue/slp/issues/3417#issuecomment-1694499120 - **consider creating a separate issue**

### Testing

Manually