### PR TITLE
Refactor matchHeader function and its usage

### DIFF
--- a/src/modules/better-table/quill-better-table.ts
+++ b/src/modules/better-table/quill-better-table.ts
@@ -153,7 +153,7 @@ export default class BetterTable extends Module {
     quill.clipboard.addMatcher("th", matchTableHeader);
     quill.clipboard.addMatcher("table", (node, delta) => matchTable(node, delta, quill, options));
     quill.clipboard.addMatcher(Node.ELEMENT_NODE, (node, delta) => matchElement(quill, node, delta));
-    quill.clipboard.addMatcher("h1, h2, h3, h4, h5, h6", (_, delta) => matchHeader(quill, delta));
+    quill.clipboard.addMatcher("h1, h2, h3, h4, h5, h6", (_, delta) => matchHeader(delta));
 
     // remove matcher for tr tag
     quill.clipboard.matchers = quill.clipboard.matchers.filter((matcher) => {

--- a/src/modules/better-table/utils/node-matchers.ts
+++ b/src/modules/better-table/utils/node-matchers.ts
@@ -244,10 +244,7 @@ export function matchElement(quill, node, delta) {
   return delta;
 }
 
-export function matchHeader(quill, delta) {
-  const range = quill.getSelection();
-  const currentBlot = quill.getLeaf(range?.index)[0];
-
+export function matchHeader(delta) {
   const parseHeadingSize = (size: number) => {
     switch (size) {
       case 1:
@@ -262,19 +259,15 @@ export function matchHeader(quill, delta) {
   };
 
   // Replace headings with p since headings in tables are not supported
-  if (currentBlot && isInTableCell(currentBlot)) {
-    const newDelta = new Delta();
+  const newDelta = new Delta();
 
-    delta.ops.map((op) => {
-      if ("header" in op.attributes) {
-        newDelta.insert(op.insert, { bold: true, size: parseHeadingSize(op.attributes.header) });
-      } else {
-        newDelta.insert(op.insert, op.attributes);
-      }
-    });
+  delta.ops.map((op) => {
+    if ("header" in op.attributes) {
+      newDelta.insert(op.insert, { bold: true, size: parseHeadingSize(op.attributes.header) });
+    } else {
+      newDelta.insert(op.insert, op.attributes);
+    }
+  });
 
-    return newDelta;
-  }
-
-  return delta;
+  return newDelta;
 }


### PR DESCRIPTION
The matchHeader function in node-matchers.ts was simplified by removing unnecessary parameters. It doesn't require quill instance anymore to work as expected. Also, updated the usage of this function accordingly in quill-better-table.ts.